### PR TITLE
use Keypolicy::MRSIGNER in seal data 

### DIFF
--- a/signatory-sgx/src/seal_data.rs
+++ b/signatory-sgx/src/seal_data.rs
@@ -116,7 +116,7 @@ fn egetkey(label: Label, seal_data: &SealData) -> Result<EgetKey, Error> {
 
     Keyrequest {
         keyname: Keyname::Seal as _,
-        keypolicy: Keypolicy::MRENCLAVE,
+        keypolicy: Keypolicy::MRSIGNER,
         isvsvn: seal_data.isvsvn,
         cpusvn: seal_data.cpusvn,
         attributemask: [!0; 2],


### PR DESCRIPTION
use `Keypolicy::MRSIGNER` in seal data so that we can reuse the sealed secret key.