### PR TITLE
add a bool argument in encode method 

### DIFF
--- a/signatory-sgx/bin/sgx_app/src/main.rs
+++ b/signatory-sgx/bin/sgx_app/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     if let Err(e) = serve(&mut stream) {
         error!("error to handle request: {:?}", e);
         let _ = Response::Error(e.what().to_string())
-            .encode()
+            .encode(true)
             .map(|data| {
                 let _ = stream.write(&data);
             })

--- a/signatory-sgx/src/backend.rs
+++ b/signatory-sgx/src/backend.rs
@@ -57,7 +57,7 @@ pub fn serve(stream: &mut TcpStream) -> Result<(), Error> {
     let request_raw_data = get_data_from_stream(stream)?;
     let response = handle_request(&request_raw_data)?;
     debug!("send response to client: {:?}", response);
-    let response_raw_data = response.encode()?;
+    let response_raw_data = response.encode(true)?;
     let _ = stream.write(&response_raw_data)?;
     Ok(())
 }

--- a/signatory-sgx/src/seal_data.rs
+++ b/signatory-sgx/src/seal_data.rs
@@ -184,7 +184,7 @@ pub fn unseal_key(label: Label, seal_data: &SealData) -> Result<EgetKey, Error> 
     egetkey(label, &seal_data)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sgx"))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
add a bool argument in `encode` method,  when send encoded data into a stream, we add a data length infromation at the front of the data,  otherwise we didn't add the data length info at the front of the encoded data.